### PR TITLE
Fix/deepseq hclose

### DIFF
--- a/mathblog.cabal
+++ b/mathblog.cabal
@@ -70,7 +70,6 @@ Executable mb
     url,
     HTTP,
     data-default,
-    system-filepath,
     JuicyPixels >= 3.1
 
   GHC-Options: -Wall

--- a/mathblog.cabal
+++ b/mathblog.cabal
@@ -48,6 +48,7 @@ Executable mb
   Main-is:         Main.hs
   Build-depends:
     base >= 3 && < 5,
+    deepseq >= 1.2,
     directory >= 1.0,
     filepath >= 1.1,
     pandoc >= 1.12,

--- a/src/MB/Gen/RSS.hs
+++ b/src/MB/Gen/RSS.hs
@@ -10,8 +10,8 @@ import Data.Time.Format
     )
 import System.Locale
     ( rfc822DateFormat
-    , defaultTimeLocale
     )
+import Data.Time.Format (defaultTimeLocale)
 import MB.Types
 import MB.Processing ( getRawPostTitle )
 import MB.Templates

--- a/src/MB/Util.hs
+++ b/src/MB/Util.hs
@@ -71,6 +71,7 @@ import Data.Maybe
 import qualified Text.Pandoc as Pandoc
 import MB.Types
 import MB.TeXMacros
+import Control.DeepSeq
 
 -- |Given a source path SRC and a destination path DST, the SRC and
 -- DST paths MUST exist and must both be directories.  All contents of
@@ -185,7 +186,7 @@ loadPostIndex ifs = do
                   True -> do
                          h <- openFile indexFilename ReadMode
                          s <- hGetContents h
-                         s `seq` return ()
+                         s `deepseq` return ()
                          let idx = unserializePostIndex s
                          hClose h
                          return idx

--- a/src/MB/Util.hs
+++ b/src/MB/Util.hs
@@ -52,7 +52,7 @@ import Data.Time.Clock
 import Data.Time.Format
     ( parseTime
     )
-import System.Locale
+import Data.Time.Format
     ( defaultTimeLocale
     )
 import System.IO
@@ -112,7 +112,7 @@ loadPost fullPath = do
   fileContent <- readFile fullPath
   t <- getModificationTime fullPath
   let doc = Pandoc.readMarkdown def fileContent
-      Pandoc.Pandoc m blocks = doc
+      Right (Pandoc.Pandoc m blocks) = doc
       -- Extract defined TeX macros in the post and store them in the
       -- post data structure to make them available to other parts of
       -- the page generation process (see Mathjax and TikZ for

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -16,7 +16,6 @@ import System.Directory
 import System.FilePath
 
 import System.FSNotify
-import qualified Filesystem.Path.CurrentOS as FP
 
 import qualified MB.Config as Config
 import MB.Server
@@ -99,7 +98,7 @@ isEventInteresting ifs ev =
            , isTemplate
            , isConfig
            , isPostIndex
-           ] <*> pure (FP.encodeString fp))
+           ] <*> pure fp)
 
 scanForChanges :: StartupConfig
                -> (GenEvent -> IO ())
@@ -131,15 +130,15 @@ scanForChanges conf h blogTrans signalAct = do
           threadDelay $ 500 * 1000
 
           ch <- newChan
-          watchTreeChan m (FP.decodeString $ dataDirectory conf) (const True) ch
+          watchTreeChan m (dataDirectory conf) (const True) ch
           let nextEv = do
                 ev <- readChan ch
                 if isEventInteresting ifs ev then return ev else nextEv
           evt <- nextEv
           case evt of
-            Added fp _ -> putStrLn $ "File created: " ++ FP.encodeString fp
-            Modified fp _ -> putStrLn $ "File modified: " ++ FP.encodeString fp
-            Removed fp _ -> putStrLn $ "File removed: " ++ FP.encodeString fp
+            Added fp _ -> putStrLn $ "File created: " ++ fp
+            Modified fp _ -> putStrLn $ "File modified: " ++ fp
+            Removed fp _ -> putStrLn $ "File removed: " ++ fp
 
 mathBackends :: [(String, Processor)]
 mathBackends =


### PR DESCRIPTION
I was getting pretty lazy IO errors.  Not sure how this worked before and what behavior changed so it doesn't work now, but it seems clear we need to entire file to be read before closing the handle.
